### PR TITLE
リリースノート生成を複数Repository追加する

### DIFF
--- a/GenerateReleaseNote/config.template.toml
+++ b/GenerateReleaseNote/config.template.toml
@@ -1,7 +1,7 @@
 [GitHub]
 token = ""
 owner = ""
-repository = ""
+repositories = []
 label = "リリースノート"
 startText = "## 対応内容"
 endText = "## 開発用メモ"


### PR DESCRIPTION
## 関連 issue

- fixes #3

## 対応内容

- モノレポを解消したので、他のRepositoryも跨げるように修正
wheatandcat/Peperomia#678
- "Peperomia","PeperomiaBackend","PeperomiaWeb","PeperomiaHelp","PeperomiaWebSite","PeperomiaTool"のレポジトリでリリースノートを生成するように修正


## 開発用メモ
無し

